### PR TITLE
Naming schema

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,9 +6,9 @@ charset = utf-8
 max_line_length = 120
 indent_style = space
 indent_size = 2
-continuation_indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+ij_continuation_indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -20,3 +20,164 @@ Maintains unique aliases for namespaces. Supports XML, HTML, and CSS.
 [github-url]: https://github.com/surol/namespace-aliaser
 [api-docs-image]: https://img.shields.io/static/v1?logo=typescript&label=API&message=docs&color=informational
 [api-docs-url]: https://surol.github.io/namespace-aliaser/
+
+
+Usage
+-----
+
+Namespaces can be used to ensure the names are unique.
+
+For doing so with the help of this library:
+
+1. Create namespace definition(s).
+2. Create `NamespaceAliaser` instance.
+3. Use that namespace aliaser to convert names from different namespaces to simple string names.
+
+The library ensures that names from different namespaces converted to different string names by applying
+unique namespace aliases to them. 
+
+```typescript
+import { newNamespaceAliaser, NamespaceDef } from 'namespace-aliaser';
+
+// Create namespace definition
+const ns1 = new NamespaceDef(
+  'http://my-site.com/ns1',  // Unique namespace URL. Namespaces are identified by their URLs.
+  'my-ns', 'my-namespace',   // Preferred namespace aliases to use.
+);
+
+// Create another namespace definition
+const ns2 = new NamespaceDef(
+  'http://my-site.com/ns2',  // Different URL
+  'my-ns', 'my-namespace-2', // Aliases could be the same for different namespaces
+                             // The library would select the one unique to each of the them,
+                             // or generate a new alias. 
+);
+
+// Create namespace aliaser.
+// It is important to use the same instance for all operations
+const nsAlias = newNamespaceAliaser();
+
+// Create aliases for each namespace
+const alias1 = nsAlias(ns1); // `my-ns`
+const alias2 = nsAlias(ns2); // `my-namespace-2`
+
+// Convert names in namespaces to simple ones, unique to each namespace
+// Even though the local names are the same, the resulting names are unique,
+// as different aliases applied.   
+const name1 = ns1.name(alias1, 'name'); // `my-ns-name`
+const name2 = ns2.name(alias2, 'name'); // `my-namespace-2-name`
+```
+
+Namespace
+---------
+
+There are several predefined namespaces:
+
+- `DEFAULT__NS` Default namespace.
+
+  This namespace is assumed for names without namespace specified.
+                                    
+  Its URL is empty. And it does not alter names, i.e. its [[NamespaceDef.name]] method returns the name as is.
+  
+- `MathML__NS` [MathML](https://www.w3.org/Math/) namespace.
+- `SVG__NS` [SVG](https://www.w3.org/Graphics/SVG/) namespace.
+- `XHTML__NS` [XHTML](https://www.w3.org/TR/xhtml1/) namespace.
+- `XML__NS` [XML](https://www.w3.org/XML/1998/namespace) namespace. Always bound to `xml` alias.
+- `XMLNS__NS` [XML Namespaces](https://www.w3.org/TR/xml-names/#ns-decl) namespace. Always bound to `xmlns` alias.
+- `XSLT__NS` [XSL Transformations](https://www.w3.org/TR/1999/REC-xslt-19991116#xslt-namespace) namespace.   
+
+More namespaces could be defined by instantiating or extending `NamespaceDef` class. Note that namespaces are
+identified by their URLs, rather by their definitions.
+
+
+Naming Schema
+-------------
+
+A naming schema is responsible for applying namespace aliases to simple names.
+
+Naming schemes extend `Naming` class.
+
+A naming schema can be passed as a third argument to `NamespaceDef.name()` method. A `default__naming` is used
+by default.
+
+So, given the previous definitions, the following code would result to different names:
+```typescript
+const xmlName1 = ns1.name(alias1, 'name', xml__naming); // `my-ns:name`
+const cssName2 = ns2.name(alias2, 'name', css__naming); // `name@my-namespace-2`
+```
+
+There are several predefined naming schemas:
+
+- `default__naming` Default naming schema.
+   
+  Prefixes a name with namespace alias separating them by dash.
+   
+  The result looks like `<alias>-<name>`.
+
+- `html__naming` HTML elements naming schema.
+
+  Prefixes a name with namespace alias separating them by dash.
+  
+  The result looks like `<alias>-<name>`.
+  
+- `xml__naming` XML elements naming schema.
+
+  Prefixes a name with namespace alias separating them by colon.
+  
+  The result looks like `<alias>:<name>`.
+  
+- `id__naming` Element identifiers naming schema.
+
+  Prefixes a name with namespace alias separating them by colon.
+  
+  The result looks like `<alias>:<name>`.
+  
+- `css__naming` CSS classes naming scheme.
+
+  Appends namespace alias as a name suffix separated by `@` sign.
+  
+  The result looks like `<name>@<alias>`.         
+
+
+Qualified Name
+--------------
+
+Qualified name is a tuple consisting of local name string and namespace definition.
+
+The `Naming` class has a utility method that allows to convert arbitrary qualified name to simple one.
+
+So, the example above could be simplified to this:
+```typescript
+import { default__naming, newNamespaceAliaser, NamespaceDef } from 'namespace-aliaser';
+
+// Create namespace definition
+const ns1 = new NamespaceDef(
+  'http://my-site.com/ns1',  // Unique namespace URL. Namespaces are identified by their URLs.
+  'my-ns', 'my-namespace',   // Preferred namespace aliases to use.
+);
+
+// Create another namespace definition
+const ns2 = new NamespaceDef(
+  'http://my-site.com/ns2',  // Different URL
+  'my-ns', 'my-namespace-2', // Aliases could be the same for different namespaces
+                             // The library would select the one unique to each of the them,
+                             // or generate a new alias. 
+);
+
+// Create namespace aliaser.
+// It is important to use the same instance for all operations
+const nsAlias = newNamespaceAliaser();
+
+// Convert qualified names to simple ones.   
+const name1 = default__naming.name(['name', ns1], nsAlias); // `my-ns-name`
+const name2 = default__naming.name(['name', ns2], nsAlias); // `my-namespace-2-name`
+```
+
+A simple string is considered a qualified name in default namespace (`DEFAULT__NS`) and can be passed to `Naming.name()`
+method too. The original name would not be altered though. So all of the following expressions would return the same
+result:
+```typescript
+default__naming.name('name', nsAlias);                // `name`
+css__naming.name('name', nsAlias);                    // `name`
+default__naming.name(['name', DEFAULT__NS], nsAlias); // `name`
+```

--- a/src/default.ns.spec.ts
+++ b/src/default.ns.spec.ts
@@ -8,7 +8,7 @@ describe('DEFAULT__NS', () => {
   });
   describe('qualify', () => {
     it('does not qualify names', () => {
-      expect(DEFAULT__NS.qualify('alias', 'some-name')).toBe('some-name');
+      expect(DEFAULT__NS.name('alias', 'some-name')).toBe('some-name');
     });
   });
 });

--- a/src/default.ns.ts
+++ b/src/default.ns.ts
@@ -9,9 +9,10 @@ class DefaultNs extends NamespaceDef {
     super('');
   }
 
-  name(alias: string, name: string): string {
+  name(_alias: string, name: string): string {
     return name;
   }
+
 }
 
 /**

--- a/src/default.ns.ts
+++ b/src/default.ns.ts
@@ -9,7 +9,7 @@ class DefaultNs extends NamespaceDef {
     super('');
   }
 
-  qualify(alias: string, name: string): string {
+  name(alias: string, name: string): string {
     return name;
   }
 }

--- a/src/default.ns.ts
+++ b/src/default.ns.ts
@@ -20,6 +20,6 @@ class DefaultNs extends NamespaceDef {
  *
  * This namespace is assumed for names without namespace specified.
  *
- * Its URL is empty. And it does not qualify any names, i.e. its [[NamespaceDef.qualify]] method returns the name as is.
+ * Its URL is empty. And it does not alter names, i.e. its [[NamespaceDef.name]] method returns the name as is.
  */
 export const DEFAULT__NS: NamespaceDef = /*#__PURE__*/ new DefaultNs();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export * from './name';
 export * from './namespace';
 export * from './namespace-aliaser';
 export * from './namespaces';
+export * from './naming';
+export * from './namings';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @module namespace-aliaser
+ */
 export * from './default.ns';
 export * from './name';
 export * from './namespace';

--- a/src/name.spec.ts
+++ b/src/name.spec.ts
@@ -7,14 +7,8 @@ import {
   namesEqual,
   namespaceOf,
   QualifiedName,
-  qualifyCssName,
-  qualifyHtmlName,
-  qualifyId,
-  qualifyName,
-  qualifyXmlName,
 } from './name';
 import { NamespaceDef } from './namespace';
-import { NamespaceAliaser, newNamespaceAliaser } from './namespace-aliaser';
 
 describe('isNameAndNamespace', () => {
   it('returns `true` for name with namespace', () => {
@@ -134,32 +128,5 @@ describe('compareNames', () => {
     expect(compareNames(['a', ns1], ['a', ns1])).toBe(0);
     expect(compareNames(['a', ns1], ['b', ns1])).toBe(-1);
     expect(compareNames(['a', ns2], ['b', ns1])).toBe(1);
-  });
-});
-
-describe('qualifyName', () => {
-
-  let ns: NamespaceDef;
-  let nsAlias: NamespaceAliaser;
-
-  beforeEach(() => {
-    ns = new NamespaceDef('test/ns', 'test');
-    nsAlias = newNamespaceAliaser();
-  });
-
-  it('does not qualify string name', () => {
-    expect(qualifyName('some-name', nsAlias)).toBe('some-name');
-  });
-  it('qualifies identifier', () => {
-    expect(qualifyId(['some-id', ns], nsAlias)).toBe('test:some-id');
-  });
-  it('qualifies XML name', () => {
-    expect(qualifyXmlName(['some-name', ns], nsAlias)).toBe('test:some-name');
-  });
-  it('qualifies HTML name', () => {
-    expect(qualifyHtmlName(['some-name', ns], nsAlias)).toBe('test-some-name');
-  });
-  it('qualifies CSS class name', () => {
-    expect(qualifyCssName(['some-class', ns], nsAlias)).toBe('some-class@test');
   });
 });

--- a/src/name.spec.ts
+++ b/src/name.spec.ts
@@ -1,27 +1,24 @@
+import { DEFAULT__NS } from './default.ns';
 import {
   compareNames,
   isNameAndNamespace,
-  isNameInNamespace,
+  isQualifiedName,
   nameAndNamespace,
-  NameInNamespace,
   namesEqual,
   namespaceOf,
+  QualifiedName,
   qualifyCssName,
   qualifyHtmlName,
   qualifyId,
   qualifyName,
-  qualifyXmlName
+  qualifyXmlName,
 } from './name';
 import { NamespaceDef } from './namespace';
 import { NamespaceAliaser, newNamespaceAliaser } from './namespace-aliaser';
-import { DEFAULT__NS } from './default.ns';
 
 describe('isNameAndNamespace', () => {
   it('returns `true` for name with namespace', () => {
     expect(isNameAndNamespace(['foo', new NamespaceDef('test/ns')])).toBe(true);
-  });
-  it('returns `false` for empty name with namespace', () => {
-    expect(isNameAndNamespace(['', new NamespaceDef('test/ns')])).toBe(false);
   });
   it('returns `false` when array is too long', () => {
     expect(isNameAndNamespace(['foo', new NamespaceDef('test/ns'), 'bar'])).toBe(false);
@@ -37,18 +34,15 @@ describe('isNameAndNamespace', () => {
   });
 });
 
-describe('isNameInNamespace', () => {
+describe('isQualifiedName', () => {
   it('returns `true` for name with namespace', () => {
-    expect(isNameInNamespace(['foo', new NamespaceDef('test/ns')])).toBe(true);
+    expect(isQualifiedName(['foo', new NamespaceDef('test/ns')])).toBe(true);
   });
   it('returns `true` for simple string name', () => {
-    expect(isNameInNamespace('foo')).toBe(true);
-  });
-  it('returns `false` for empty string', () => {
-    expect(isNameInNamespace('')).toBe(false);
+    expect(isQualifiedName('foo')).toBe(true);
   });
   it('returns `false` for everything else', () => {
-    expect(isNameInNamespace(['foo', 'bar'])).toBe(false);
+    expect(isQualifiedName(['foo', 'bar'])).toBe(false);
   });
 });
 
@@ -67,7 +61,7 @@ describe('namespaceOf', () => {
 describe('nameAndNamespace', () => {
   it('returns the name itself for the name with namespace', () => {
 
-    const name: NameInNamespace = ['some-name', new NamespaceDef('test/url')];
+    const name: QualifiedName = ['some-name', new NamespaceDef('test/url')];
 
     expect(nameAndNamespace(name)).toBe(name);
   });

--- a/src/name.ts
+++ b/src/name.ts
@@ -1,9 +1,8 @@
 /**
  * @module namespace-aliaser
  */
-import { NameScope, NamespaceDef } from './namespace';
-import { NamespaceAliaser } from './namespace-aliaser';
 import { DEFAULT__NS } from './default.ns';
+import { NamespaceDef } from './namespace';
 
 /**
  * A name qualified with namespace.
@@ -130,77 +129,4 @@ export function compareNames(first: QualifiedName, second: QualifiedName): -1 | 
 
 function compareStrings(first: string, second: string): -1 | 0 | 1 {
   return first < second ? -1 : first > second ? 1 : 0;
-}
-
-/**
- * Qualifies the given `name` by applying namespace alias to it.
- *
- * Utilizes  method for that.
- *
- * @param name  Name to qualify.
- * @param nsAlias  Namespace alias to apply.
- * @param scope  Name usage scope.
- *
- * @returns `name` itself for plain string names, or the result of [[NamespaceDef.qualify]] method applied to the `name`
- * and namespace alias returned by `nsAlias` namespace aliaser.
- */
-export function qualifyName(
-    name: QualifiedName,
-    nsAlias: NamespaceAliaser,
-    scope?: NameScope): string {
-  if (typeof name === 'string') {
-    return name;
-  }
-
-  const [local, ns] = name;
-
-  return ns.name(nsAlias(ns), local, scope);
-}
-
-/**
- * Qualifies the given `id` for its usage as identifier.
- *
- * @param id  An identifier to qualify.
- * @param nsAlias  A namespace aliaser to use.
- *
- * @returns `qualifyName(id, nsAlias, 'id')`.
- */
-export function qualifyId(id: QualifiedName, nsAlias: NamespaceAliaser): string {
-  return qualifyName(id, nsAlias, 'id');
-}
-
-/**
- * Qualifies the given `name` for its usage as XML element name.
- *
- * @param name  A name to qualify.
- * @param nsAlias  A namespace aliaser to use.
- *
- * @returns `qualifyName(id, nsAlias, 'xml')`.
- */
-export function qualifyXmlName(name: QualifiedName, nsAlias: NamespaceAliaser): string {
-  return qualifyName(name, nsAlias, 'xml');
-}
-
-/**
- * Qualifies the given `name` for its usage as HTML element name.
- *
- * @param name  A name to qualify.
- * @param nsAlias  A namespace aliaser to use.
- *
- * @returns `qualifyName(id, nsAlias, 'html')`.
- */
-export function qualifyHtmlName(name: QualifiedName, nsAlias: NamespaceAliaser): string {
-  return qualifyName(name, nsAlias, 'html');
-}
-
-/**
- * Qualifies the given `name` for its usage as CSS class name.
- *
- * @param name  A name to qualify.
- * @param nsAlias  A namespace aliaser to use.
- *
- * @returns `qualifyName(id, nsAlias, 'css')`.
- */
-export function qualifyCssName(name: QualifiedName, nsAlias: NamespaceAliaser): string {
-  return qualifyName(name, nsAlias, 'css');
 }

--- a/src/name.ts
+++ b/src/name.ts
@@ -6,18 +6,18 @@ import { NamespaceAliaser } from './namespace-aliaser';
 import { DEFAULT__NS } from './default.ns';
 
 /**
- * A name in some namespace.
+ * A name qualified with namespace.
  *
  * This can be either:
- * - a simple non-empty name string, which means a name in the default namespace, or
+ * - a simple name string, which means a name in default namespace, or
  * - a name+namespace tuple.
  */
-export type NameInNamespace = string | NameAndNamespace;
+export type QualifiedName = string | NameAndNamespace;
 
 /**
- * A name and namespace tuple.
+ * A local name and namespace tuple.
  *
- * Consists of non-empty name and namespace definition this name belongs to.
+ * Consists of a local name string and namespace definition this name belongs to.
  */
 export type NameAndNamespace = readonly [string, NamespaceDef];
 
@@ -33,12 +33,11 @@ export function isNameAndNamespace(value: any): value is NameAndNamespace {
   return Array.isArray(value)
       && value.length === 2
       && typeof value[0] === 'string'
-      && !!value[0]
       && value[1] instanceof NamespaceDef;
 }
 
 /**
- * Checks whether the given `value` is a name in some namespace.
+ * Checks whether the given `value` is a qualified name.
  *
  * @param value  A value to check.
  *
@@ -46,42 +45,42 @@ export function isNameAndNamespace(value: any): value is NameAndNamespace {
  * where the first element is a non-empty string, and the second element is an instance of [[NamespaceDef]].
  * Or `false` otherwise.
  */
-export function isNameInNamespace(value: any): value is NameInNamespace {
-  return (typeof value === 'string' && !!value) || isNameAndNamespace(value);
+export function isQualifiedName(value: any): value is QualifiedName {
+  return typeof value === 'string' || isNameAndNamespace(value);
 }
 
 /**
  * Detects a namespace of the given `name`
  *
- * @param name  A name to detect namespace of.
+ * @param name  Qualified name to detect namespace of.
  *
  * @returns A namespace if the given `name` has it, or {@link DEFAULT__NS default namespace} otherwise.
  */
-export function namespaceOf(name: NameInNamespace): NamespaceDef {
+export function namespaceOf(name: QualifiedName): NamespaceDef {
   return typeof name !== 'string' ? name[1] : DEFAULT__NS;
 }
 
 /**
- * Converts the given `name` to name and namespace tuple.
+ * Converts the given qualified `name` to name and namespace tuple.
  *
- * @param name  A name to convert.
+ * @param name  Qualified name to convert.
  *
  * @returns The `name` itself if it has a namespace, or a tuple consisting of `name` and
  * {@link DEFAULT__NS default namespace} otherwise.
  */
-export function nameAndNamespace(name: NameInNamespace): NameAndNamespace {
+export function nameAndNamespace(name: QualifiedName): NameAndNamespace {
   return typeof name !== 'string' ? name : [name, DEFAULT__NS];
 }
 
 /**
- * Checks whether two names are equal to each other.
+ * Checks whether two qualified names are equal to each other.
  *
- * @param first  First name to compare.
- * @param second  Second name to compare.
+ * @param first  First qualified name to compare.
+ * @param second  Second qualified name to compare.
  *
  * @returns `true` if both names are equal, or `false` otherwise.
  */
-export function namesEqual(first: NameInNamespace, second: NameInNamespace): boolean {
+export function namesEqual(first: QualifiedName, second: QualifiedName): boolean {
   if (typeof first === 'string') {
     return typeof second === 'string' ? first === second : !second[1].url && second[0] === first;
   }
@@ -96,17 +95,17 @@ export function namesEqual(first: NameInNamespace, second: NameInNamespace): boo
 }
 
 /**
- * Compares two names.
+ * Compares two qualified names.
  *
  * Names in default namespace considered less than other names. Namespaces are compared by their URLs.
  *
- * @param first  First name to compare.
- * @param second  Second name to compare.
+ * @param first  First qualified name to compare.
+ * @param second  Second qualified name to compare.
  *
- * @returns `-1` if `first` name is less than `second` one, `0` if they are equal, or `1` if `first` name is greater
- * than `second` one.
+ * @returns `-1` if the `first` name is less than the `second` one, `0` if they are equal, or `1` if the `first` name
+ * is greater than the `second` one.
  */
-export function compareNames(first: NameInNamespace, second: NameInNamespace): -1 | 0 | 1 {
+export function compareNames(first: QualifiedName, second: QualifiedName): -1 | 0 | 1 {
   if (typeof first === 'string') {
     if (typeof second === 'string') {
       return compareStrings(first, second);
@@ -146,7 +145,7 @@ function compareStrings(first: string, second: string): -1 | 0 | 1 {
  * and namespace alias returned by `nsAlias` namespace aliaser.
  */
 export function qualifyName(
-    name: NameInNamespace,
+    name: QualifiedName,
     nsAlias: NamespaceAliaser,
     scope?: NameScope): string {
   if (typeof name === 'string') {
@@ -155,7 +154,7 @@ export function qualifyName(
 
   const [local, ns] = name;
 
-  return ns.qualify(nsAlias(ns), local, scope);
+  return ns.name(nsAlias(ns), local, scope);
 }
 
 /**
@@ -166,7 +165,7 @@ export function qualifyName(
  *
  * @returns `qualifyName(id, nsAlias, 'id')`.
  */
-export function qualifyId(id: NameInNamespace, nsAlias: NamespaceAliaser): string {
+export function qualifyId(id: QualifiedName, nsAlias: NamespaceAliaser): string {
   return qualifyName(id, nsAlias, 'id');
 }
 
@@ -178,7 +177,7 @@ export function qualifyId(id: NameInNamespace, nsAlias: NamespaceAliaser): strin
  *
  * @returns `qualifyName(id, nsAlias, 'xml')`.
  */
-export function qualifyXmlName(name: NameInNamespace, nsAlias: NamespaceAliaser): string {
+export function qualifyXmlName(name: QualifiedName, nsAlias: NamespaceAliaser): string {
   return qualifyName(name, nsAlias, 'xml');
 }
 
@@ -190,7 +189,7 @@ export function qualifyXmlName(name: NameInNamespace, nsAlias: NamespaceAliaser)
  *
  * @returns `qualifyName(id, nsAlias, 'html')`.
  */
-export function qualifyHtmlName(name: NameInNamespace, nsAlias: NamespaceAliaser): string {
+export function qualifyHtmlName(name: QualifiedName, nsAlias: NamespaceAliaser): string {
   return qualifyName(name, nsAlias, 'html');
 }
 
@@ -202,6 +201,6 @@ export function qualifyHtmlName(name: NameInNamespace, nsAlias: NamespaceAliaser
  *
  * @returns `qualifyName(id, nsAlias, 'css')`.
  */
-export function qualifyCssName(name: NameInNamespace, nsAlias: NamespaceAliaser): string {
+export function qualifyCssName(name: QualifiedName, nsAlias: NamespaceAliaser): string {
   return qualifyName(name, nsAlias, 'css');
 }

--- a/src/name.ts
+++ b/src/name.ts
@@ -49,9 +49,9 @@ export function isQualifiedName(value: any): value is QualifiedName {
 }
 
 /**
- * Detects a namespace of the given `name`
+ * Detects a namespace of the given qualified `name`
  *
- * @param name  Qualified name to detect namespace of.
+ * @param name  Qualified name to detect a namespace of.
  *
  * @returns A namespace if the given `name` has it, or {@link DEFAULT__NS default namespace} otherwise.
  */
@@ -60,7 +60,7 @@ export function namespaceOf(name: QualifiedName): NamespaceDef {
 }
 
 /**
- * Converts the given qualified `name` to name and namespace tuple.
+ * Converts the given qualified `name` to local name and namespace tuple.
  *
  * @param name  Qualified name to convert.
  *

--- a/src/namespace-aliaser.ts
+++ b/src/namespace-aliaser.ts
@@ -7,12 +7,14 @@ import { NamespaceDef } from './namespace';
  * Namespace aliaser function interface.
  *
  * Maps namespaces to their unique aliases.
- *
+ */
+export type NamespaceAliaser =
+/**
  * @param ns  A definition of namespace to find alias for.
  *
  * @returns Namespace alias.
  */
-export type NamespaceAliaser = (ns: NamespaceDef) => string;
+    (ns: NamespaceDef) => string;
 
 /**
  * Creates a namespace aliaser.

--- a/src/namespace.spec.ts
+++ b/src/namespace.spec.ts
@@ -1,25 +1,27 @@
 import { NamespaceDef } from './namespace';
+import { Naming } from './naming';
+import Mocked = jest.Mocked;
 
 describe('NamespaceDef', () => {
-  describe('localName', () => {
 
-    let ns: NamespaceDef;
+  let ns: NamespaceDef;
+  let naming: Mocked<Naming>;
 
-    beforeEach(() => {
-      ns = new NamespaceDef('test/url');
-    });
+  beforeEach(() => {
+    ns = new NamespaceDef('test/url');
+    naming = {
+      applyAlias: jest.fn((name, alias, _ns) => `${name}/${alias}`),
+      name: jest.fn(),
+    };
+  });
 
-    it('appends suffix to CSS class names', () => {
-      expect(ns.name('ns', 'class-name', 'css')).toBe('class-name@ns');
+  describe('name', () => {
+    it('applies naming schema', () => {
+      expect(ns.name('ns', 'local-name', naming)).toBe('local-name/ns');
+      expect(naming.applyAlias).toHaveBeenCalledWith('local-name', 'ns', ns);
     });
-    it('prefixes ID', () => {
-      expect(ns.name('ns', 'id', 'id')).toBe('ns:id');
-    });
-    it('prefixes XML name', () => {
-      expect(ns.name('ns', 'name', 'xml')).toBe('ns:name');
-    });
-    it('prefixes other names', () => {
-      expect(ns.name('ns', 'element-name')).toBe('ns-element-name');
+    it('applies default naming schema when omitted', () => {
+      expect(ns.name('ns', 'local-name')).toBe('ns-local-name');
     });
   });
 

--- a/src/namespace.spec.ts
+++ b/src/namespace.spec.ts
@@ -10,16 +10,16 @@ describe('NamespaceDef', () => {
     });
 
     it('appends suffix to CSS class names', () => {
-      expect(ns.qualify('ns', 'class-name', 'css')).toBe('class-name@ns');
+      expect(ns.name('ns', 'class-name', 'css')).toBe('class-name@ns');
     });
     it('prefixes ID', () => {
-      expect(ns.qualify('ns', 'id', 'id')).toBe('ns:id');
+      expect(ns.name('ns', 'id', 'id')).toBe('ns:id');
     });
     it('prefixes XML name', () => {
-      expect(ns.qualify('ns', 'name', 'xml')).toBe('ns:name');
+      expect(ns.name('ns', 'name', 'xml')).toBe('ns:name');
     });
     it('prefixes other names', () => {
-      expect(ns.qualify('ns', 'element-name')).toBe('ns-element-name');
+      expect(ns.name('ns', 'element-name')).toBe('ns-element-name');
     });
   });
 

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -41,7 +41,7 @@ export class NamespaceDef {
   }
 
   /**
-   * Qualifies a local name in this namespace. E.g by prefixing it with namespace alias.
+   * Converts a local `name` belonging to this namespace to simple one according to the given naming schema.
    *
    * By default:
    * - qualifies `name` in `id` and `xml` scopes as `<alias>:<name>`, which is valid XML and HTML4 ID,
@@ -54,7 +54,7 @@ export class NamespaceDef {
    *
    * @returns A name qualified with namespace alias.
    */
-  qualify(alias: string, name: string, scope?: NameScope): string {
+  name(alias: string, name: string, scope?: NameScope): string {
     switch (scope) {
       case 'id':
       case 'xml':

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,6 +1,9 @@
 /**
  * @module namespace-aliaser
  */
+import { Naming } from './naming';
+import { default__naming } from './namings';
+
 /**
  * Namespace definition.
  *
@@ -41,39 +44,18 @@ export class NamespaceDef {
   }
 
   /**
-   * Converts a local `name` belonging to this namespace to simple one according to the given naming schema.
+   * Converts a local `name` belonging to this namespace to simple one according to the given `naming` schema.
    *
-   * By default:
-   * - qualifies `name` in `id` and `xml` scopes as `<alias>:<name>`, which is valid XML and HTML4 ID,
-   * - qualifies `name` in `css` scope as `<name>@<alias>`,
-   * - qualifies `name` in `html` and other scopes as `<alias>-<name>`.
+   * Calls [[Naming.applyAlias]] by default.
    *
    * @param alias  Namespace alias to apply to the name.
    * @param name  A name to convert.
-   * @param scope  Name usage scope.
+   * @param naming  Naming schema to use. {@link default__naming default naming schema} is used when omitted.
    *
-   * @returns A name qualified with namespace alias.
+   * @returns A simple name with this namespace alias applied.
    */
-  name(alias: string, name: string, scope?: NameScope): string {
-    switch (scope) {
-      case 'id':
-      case 'xml':
-        return `${alias}:${name}`;
-      case 'css':
-        return `${name}@${alias}`;
-    }
-    return `${alias}-${name}`;
+  name(alias: string, name: string, naming: Naming = default__naming): string {
+    return naming.applyAlias(name, alias, this);
   }
 
 }
-
-/**
- * Name usage scope.
- *
- * The following scopes supported:
- * - `id` for element identifiers,
- * - `xml` for XML element names,
- * - `html` for HTML element names,
- * - `css` for CSS class names.
- */
-export type NameScope = 'id' | 'xml' | 'html' | 'css';

--- a/src/namespaces.ts
+++ b/src/namespaces.ts
@@ -21,14 +21,14 @@ export const XHTML__NS = /*#__PURE__*/ new NamespaceDef('http://www.w3.org/1999/
 /**
  * [XML](https://www.w3.org/XML/1998/namespace) namespace definition.
  *
- * It is always bound to `xml` prefix.
+ * It is always bound to `xml` alias.
  */
 export const XML__NS = /*#__PURE__*/ new NamespaceDef('http://www.w3.org/XML/1998/namespace', 'xml');
 
 /**
  * [XML Namespaces](https://www.w3.org/TR/xml-names/#ns-decl) namespace definition.
  *
- * It is always bound to `xmlns` prefix and should never be declared.
+ * It is always bound to `xmlns` alias and should never be declared.
  */
 export const XMLNS__NS = /*#__PURE__*/ new NamespaceDef('http://www.w3.org/2000/xmlns/', 'xmlns');
 

--- a/src/naming.ts
+++ b/src/naming.ts
@@ -1,0 +1,41 @@
+/**
+ * @module namespace-aliaser
+ */
+import { QualifiedName } from './name';
+import { NamespaceDef } from './namespace';
+import { NamespaceAliaser } from './namespace-aliaser';
+
+/**
+ * Naming schema is responsible for applying namespace aliases to simple names. E.g. by appending alias as prefix or
+ * suffix of the name.
+ */
+export abstract class Naming {
+
+  /**
+   * Applies the given namespace `alias` to the given local `name`.
+   *
+   * @param name Local name to apply namespace alias to.
+   * @param alias Namespace alias to apply.
+   * @param namespace Aliased namespace definition.
+   *
+   * @returns A string containing the `name` with `alias` applied to it.
+   */
+  abstract applyAlias(name: string, alias: string, namespace: NamespaceDef): string;
+
+  /**
+   * Converts the given qualified `name` into simple one accordingly to this naming schema.
+   *
+   * @param name Qualified name to convert.
+   * @param nsAlias Namespace aliaser to use.
+   */
+  name(name: QualifiedName, nsAlias: NamespaceAliaser): string {
+    if (typeof name === 'string') {
+      return name;
+    }
+
+    const [local, ns] = name;
+
+    return ns.name(nsAlias(ns), local, this);
+  }
+
+}

--- a/src/namings.spec.ts
+++ b/src/namings.spec.ts
@@ -1,0 +1,47 @@
+import { NamespaceDef } from './namespace';
+import { NamespaceAliaser, newNamespaceAliaser } from './namespace-aliaser';
+import { css__naming, default__naming, html__naming, id__naming, xml__naming } from './namings';
+
+describe('namings', () => {
+
+  let ns: NamespaceDef;
+  let nsAlias: NamespaceAliaser;
+
+  beforeEach(() => {
+    ns = new NamespaceDef('test/ns', 'test');
+    nsAlias = newNamespaceAliaser();
+  });
+
+  describe('default__naming', () => {
+    it('does not prefix simple name', () => {
+      expect(default__naming.name('some-name', nsAlias)).toBe('some-name');
+    });
+    it('prefixes name', () => {
+      expect(default__naming.name(['some-id', ns], nsAlias)).toBe('test-some-id');
+    });
+  });
+
+  describe('html__naming', () => {
+    it('prefixes name', () => {
+      expect(html__naming.name(['some-id', ns], nsAlias)).toBe('test-some-id');
+    });
+  });
+
+  describe('xml__naming', () => {
+    it('prefixes name', () => {
+      expect(xml__naming.name(['some-id', ns], nsAlias)).toBe('test:some-id');
+    });
+  });
+
+  describe('id__naming', () => {
+    it('prefixes name', () => {
+      expect(id__naming.name(['some-id', ns], nsAlias)).toBe('test:some-id');
+    });
+  });
+
+  describe('css__naming', () => {
+    it('appends namespace alias', () => {
+      expect(css__naming.name(['some-id', ns], nsAlias)).toBe('some-id@test');
+    });
+  });
+});

--- a/src/namings.ts
+++ b/src/namings.ts
@@ -14,7 +14,7 @@ class DefaultNaming extends Naming {
 /**
  * Default naming schema.
  *
- * Prefixes names with namespace aliases separating them by dash.
+ * Prefixes a name with namespace alias separating them by dash.
  *
  * The result looks like `<alias>-<name>`.
  */
@@ -23,7 +23,7 @@ export const default__naming: Naming = /*#__PURE__*/ new DefaultNaming();
 /**
  * HTML elements naming schema.
  *
- * Prefixes names with namespace aliases separating them by dash.
+ * Prefixes a name with namespace alias separating them by dash.
  *
  * The result looks like `<alias>-<name>`.
  */
@@ -40,7 +40,7 @@ class XmlNaming extends Naming {
 /**
  * XML elements naming schema.
  *
- * Prefixes names with namespace aliases separating them by colon.
+ * Prefixes a name with namespace alias separating them by colon.
  *
  * The result looks like `<alias>:<name>`.
  */
@@ -49,7 +49,7 @@ export const xml__naming: Naming = /*#__PURE__*/ new XmlNaming();
 /**
  * Element identifiers naming schema.
  *
- * Prefixes names with namespace aliases separating them by colon.
+ * Prefixes a name with namespace alias separating them by colon.
  *
  * The result looks like `<alias>:<name>`.
  */
@@ -66,7 +66,7 @@ class CssNaming extends Naming {
 /**
  * CSS classes naming scheme.
  *
- * Appends namespace alias as a suffix separated by `@` sign.
+ * Appends namespace alias as a name suffix separated by `@` sign.
  *
  * The result looks like `<name>@<alias>`.
  */

--- a/src/namings.ts
+++ b/src/namings.ts
@@ -1,0 +1,73 @@
+/**
+ * @module namespace-aliaser
+ */
+import { Naming } from './naming';
+
+class DefaultNaming extends Naming {
+
+  applyAlias(name: string, alias: string): string {
+    return `${alias}-${name}`;
+  }
+
+}
+
+/**
+ * Default naming schema.
+ *
+ * Prefixes names with namespace aliases separating them by dash.
+ *
+ * The result looks like `<alias>-<name>`.
+ */
+export const default__naming: Naming = /*#__PURE__*/ new DefaultNaming();
+
+/**
+ * HTML elements naming schema.
+ *
+ * Prefixes names with namespace aliases separating them by dash.
+ *
+ * The result looks like `<alias>-<name>`.
+ */
+export const html__naming: Naming = /*#__PURE__*/ new DefaultNaming();
+
+class XmlNaming extends Naming {
+
+  applyAlias(name: string, alias: string): string {
+    return `${alias}:${name}`;
+  }
+
+}
+
+/**
+ * XML elements naming schema.
+ *
+ * Prefixes names with namespace aliases separating them by colon.
+ *
+ * The result looks like `<alias>:<name>`.
+ */
+export const xml__naming: Naming = /*#__PURE__*/ new XmlNaming();
+
+/**
+ * Element identifiers naming schema.
+ *
+ * Prefixes names with namespace aliases separating them by colon.
+ *
+ * The result looks like `<alias>:<name>`.
+ */
+export const id__naming: Naming = /*#__PURE__*/ new XmlNaming();
+
+class CssNaming extends Naming {
+
+  applyAlias(name: string, alias: string): string {
+    return `${name}@${alias}`;
+  }
+
+}
+
+/**
+ * CSS classes naming scheme.
+ *
+ * Appends namespace alias as a suffix separated by `@` sign.
+ *
+ * The result looks like `<name>@<alias>`.
+ */
+export const css__naming: Naming = /*#__PURE__*/ new CssNaming();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "experimentalDecorators": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "noEmitHelpers": true,


### PR DESCRIPTION
- Replace `NameScope` with `Naming` schema.
- Rename `NameInNamespace` to `QualifiedName`.
- Rename `NamespaceDef.qualify()` method to `NamespaceDef.name()`.
- `qualifyXXX` functions are replaced with `Naming.name()` method.