### PR TITLE
Check if `NamespaceDef` is implemented structurally

### DIFF
--- a/src/name.spec.ts
+++ b/src/name.spec.ts
@@ -15,6 +15,30 @@ describe('isNameAndNamespace', () => {
   it('returns `true` for name with namespace', () => {
     expect(isNameAndNamespace(['foo', new NamespaceDef('test/ns')])).toBe(true);
   });
+  it('returns `true` if the second element has a `NamespaceDef` structure', () => {
+    expect(isNameAndNamespace([
+      'foo',
+      { url: 'test/ns', alias: 'test', aliases: ['test'], name: NamespaceDef.prototype.name },
+    ])).toBe(true);
+  });
+  it('returns `false` if the second element has a non-`NamespaceDef` structure', () => {
+    expect(isNameAndNamespace([
+      'foo',
+      { url: { href: 'test/ns' }, alias: 'test', aliases: ['test'], name: NamespaceDef.prototype.name },
+    ])).toBe(false);
+    expect(isNameAndNamespace([
+      'foo',
+      { url: 'test/ns', alias: 1, aliases: ['test'], name: NamespaceDef.prototype.name },
+    ])).toBe(false);
+    expect(isNameAndNamespace([
+      'foo',
+      { url: 'test/ns', alias: 'test', aliases: {}, name: NamespaceDef.prototype.name },
+    ])).toBe(false);
+    expect(isNameAndNamespace([
+      'foo',
+      { url: 'test/ns', alias: 'test', aliases: ['test'], name: 'test' },
+    ])).toBe(false);
+  });
   it('returns `false` when array is too long', () => {
     expect(isNameAndNamespace(['foo', new NamespaceDef('test/ns'), 'bar'])).toBe(false);
   });

--- a/src/name.ts
+++ b/src/name.ts
@@ -29,7 +29,18 @@ export function isNameAndNamespace(value: unknown): value is NameAndNamespace {
   return Array.isArray(value)
       && value.length === 2
       && typeof value[0] === 'string'
-      && value[1] instanceof NamespaceDef;
+      && isNamespaceDef(value[1]);
+}
+
+function isNamespaceDef(value: unknown): value is NamespaceDef {
+  if (value instanceof NamespaceDef) {
+    return true;
+  }
+  return typeof value === 'object'
+      && typeof (value as Partial<NamespaceDef>).url === 'string'
+      && typeof (value as Partial<NamespaceDef>).alias === 'string'
+      && Array.isArray((value as Partial<NamespaceDef>).aliases)
+      && typeof (value as Partial<NamespaceDef>).name === 'function';
 }
 
 /**


### PR DESCRIPTION
This allows to use the package as runtime dependency, not only a peer dependency﻿

This would work in case of multiple versions of the package co-existence.
